### PR TITLE
filter for none values in name attribute

### DIFF
--- a/chemlog_extra/alg_classification/by_element_classification.py
+++ b/chemlog_extra/alg_classification/by_element_classification.py
@@ -59,13 +59,12 @@ class XMolecularEntityClassifier(ExtraClassifier):
         element_name_to_num = {Chem.GetPeriodicTable().GetElementName(i).lower(): i for i in range(2, 119)}
         element_class_mapping = {}
         for chebi_id, properties in self.chebi_graph.nodes.items():
-            if "name" in properties:
-                if " molecular entity" in properties["name"]:
-                    element_name = properties["name"].split(" ")[0]
-                    if element_name == "organic":
-                        element_name = "carbon"
-                    if element_name in element_name_to_num:
-                        element_class_mapping[element_name_to_num[element_name]] = str(chebi_id)
+            if properties.get("name") and " molecular entity" in properties["name"]:
+                element_name = properties["name"].split(" ")[0]
+                if element_name == "organic":
+                    element_name = "carbon"
+                if element_name in element_name_to_num:
+                    element_class_mapping[element_name_to_num[element_name]] = str(chebi_id)
         return element_class_mapping
 
     def get_single_classification(self, mol, element_num):
@@ -84,17 +83,8 @@ class OrganoXCompoundClassifier(ExtraClassifier):
         element_name_to_num = {Chem.GetPeriodicTable().GetElementName(i).lower(): i for i in range(1, 119) if i != 15}
         element_class_mapping = {}
         for chebi_id, properties in self.chebi_graph.nodes.items():
-            if "name" in properties:
-                if properties["name"].startswith("organo") and " compound" in properties["name"]:
-                    element_name = properties["name"][6:].split(" ")[0]
-                    if element_name in element_name_to_num:
-                        element_class_mapping[element_name_to_num[element_name]] = str(chebi_id)
+            if properties.get("name") and properties["name"].startswith("organo") and " compound" in properties["name"]:
+                element_name = properties["name"][6:].split(" ")[0]
+                if element_name in element_name_to_num:
+                    element_class_mapping[element_name_to_num[element_name]] = str(chebi_id)
         return element_class_mapping
-
-if __name__ == "__main__":
-    from chebifier.utils import build_chebi_graph
-    chebi_graph = build_chebi_graph(chebi_version=244)
-    classifier = XMolecularEntityClassifier(chebi_graph, chebi_version=244)
-    print(classifier.classify([Chem.MolFromSmiles("C12=C(N(C(=O)N(C)C1=O)C)N=CN2C.C1(=CC=CC=C1)C(=O)[O-].[Na+]")]))
-    classifier = OrganoXCompoundClassifier(chebi_graph, chebi_version=244)
-    print(classifier.classify([Chem.MolFromSmiles("C12=C(N(C(=O)N(C)C1=O)C)N=CN2C.C1(=CC=CC=C1)C(=O)[O-].[Na+]")]))


### PR DESCRIPTION
I got an error while running chebifier with the latest [chebi graph](https://huggingface.co/datasets/chebai/chebifier/blob/main/chebi_graph.pkl). Apparently, we have none values in `properties["name"]`. This fix filters for both the existence of the name column and that it contains a value.

Full error message:

```
Initialised GNN model resgated-aug_chebi50-3star_v244 (device: cuda)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chebifier/__main__.py", line 4, in <module>
    cli()
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/click/core.py", line 1569, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/click/core.py", line 1490, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/click/core.py", line 1970, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/click/core.py", line 1353, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/click/core.py", line 907, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chebifier/cli.py", line 74, in predict
    ensemble = ENSEMBLES[ensemble_type](
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chebifier/ensemble/weighted_majority_ensemble.py", line 76, in __init__
    super().__init__(config_path, **kwargs)
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chebifier/ensemble/base_ensemble.py", line 68, in __init__
    model_instance = model_cls(
                     ^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chebifier/prediction_models/chemlog_predictor.py", line 40, in __init__
    ChemlogXMolecularEntityPredictor("chemlog_x_molecular_entity", **kwargs),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chebifier/prediction_models/chemlog_predictor.py", line 97, in __init__
    self.classifier = XMolecularEntityClassifier(chebi_graph=self.chebi_graph)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chemlog_extra/alg_classification/by_element_classification.py", line 12, in __init__
    self.element_class_mapping = self.load_element_class_mapping()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chemlog_extra/alg_classification/by_element_classification.py", line 43, in load_element_class_mapping
    mapping = self.build_class_element_mapping()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/sifluegel/Desktop/chebifier-demo/.venv/lib/python3.12/site-packages/chemlog_extra/alg_classification/by_element_classification.py", line 63, in build_class_element_mapping
    if " molecular entity" in properties["name"]:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```
